### PR TITLE
Scrape sendo reviews by product name

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,9 +5,8 @@ from scrape.sendo_scrape import scrape_sendo
 from scrape.tiki_scrape import scrape_tiki
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
-from scrape.sendo_scrape import CHROME_DRIVER_PATH
 
-# CHROME_DRIVER_PATH = "D:/chromedriver.exe"
+CHROME_DRIVER_PATH = "D:/chromedriver.exe"
 
 app = Flask(__name__)
 api = Api(app)

--- a/app.py
+++ b/app.py
@@ -38,7 +38,7 @@ class GetReview(Resource):
         driver = webdriver.Chrome(CHROME_DRIVER_PATH, options=chrome_options)
 
         if site == 'sendo':
-            result = scrape_sendo(driver=driver, input=url, max_review_num=5, verbose=True)
+            result = scrape_sendo(driver=driver, url=url, max_review_num=5, verbose=True)
         elif site == 'lazada':
             result = scrape_lazada(driver, url, 4)
         elif site == 'tiki':

--- a/app.py
+++ b/app.py
@@ -5,8 +5,9 @@ from scrape.sendo_scrape import scrape_sendo
 from scrape.tiki_scrape import scrape_tiki
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
+from scrape.sendo_scrape import CHROME_DRIVER_PATH
 
-CHROME_DRIVER_PATH = "D:/chromedriver.exe"
+# CHROME_DRIVER_PATH = "D:/chromedriver.exe"
 
 app = Flask(__name__)
 api = Api(app)
@@ -38,7 +39,7 @@ class GetReview(Resource):
         driver = webdriver.Chrome(CHROME_DRIVER_PATH, options=chrome_options)
 
         if site == 'sendo':
-            result = scrape_sendo(driver=driver, url=url, max_review_num=5, verbose=True)
+            result = scrape_sendo(driver=driver, input=url, max_review_num=5, verbose=True)
         elif site == 'lazada':
             result = scrape_lazada(driver, url, 4)
         elif site == 'tiki':

--- a/scrape/sendo_scrape.py
+++ b/scrape/sendo_scrape.py
@@ -168,13 +168,13 @@ def scrape_sendo(driver, url, max_review_num=20, review_check_num=10, review_wai
         # create a dictionary to store review information
         result = {
             "product_name": None,
-            "total" : None,
+            "average_rating" : None,
             "source" : "sendo",
             "reviews" : []
         }
         
-        # wait for cumulative rating to be loaded before cooking soup
-        cum = WebDriverWait(driver, review_wait_time).until(
+        # wait for average rating to be loaded before cooking soup
+        WebDriverWait(driver, review_wait_time).until(
                             EC.presence_of_element_located((By.CLASS_NAME, "_39a-7b5c89")))
 
         # cook soup
@@ -185,10 +185,10 @@ def scrape_sendo(driver, url, max_review_num=20, review_check_num=10, review_wai
         result["product_name"] = product_name
         logging.info(f"Got product's name: {product_name}")
 
-        # cumulative rating
-        total = soup.find(class_="_39a-7b5c89").text
-        result["total"] = total
-        logging.info(f"Got cumulative rating: {total}")
+        # average rating
+        avg = soup.find(class_="_39a-7b5c89").text
+        result["average_rating"] = avg
+        logging.info(f"Got average rating: {avg}")
 
         # get the reviews
         reviews = soup.find_all(class_="_39a-71cc39")

--- a/scrape/sendo_scrape.py
+++ b/scrape/sendo_scrape.py
@@ -15,7 +15,7 @@ STAR_RATING_CONVERT = {
     "d7e-4e4dcb d7e-9ac674" : 2,
     "d7e-4e4dcb d7e-fede87" : 1
     }
-CHROME_DRIVER_PATH = "/home/viet/OneDrive/Studying Materials/Introduction to Data Science/EDA Project/chromedriver_linux64/chromedriver"
+CHROME_DRIVER_PATH = "/home/viet/OneDrive/Studying_Materials/Introduction_to_Data_Science/EDA Project/chromedriver_linux64/chromedriver"
 REVIEW_COUNTER = 0
 
 


### PR DESCRIPTION
Scrape by product name is now supported for sendo. Scraped products are stored in a list. The number of products to be scraped can be configured in the product_num argument.

Sample:

![image](https://user-images.githubusercontent.com/73997794/174357308-a21d6eef-513c-4e95-aab5-724cb806891d.png)
![image](https://user-images.githubusercontent.com/73997794/174357491-28dbbda8-521c-475b-bdd1-1069daa7ee8e.png)